### PR TITLE
Use the  initializer as a target instead of the soon to be deprecated…

### DIFF
--- a/addon/initializers/extend-ds-model.js
+++ b/addon/initializers/extend-ds-model.js
@@ -7,6 +7,6 @@ export function initialize(/* container, application */) {
 
 export default {
   name:       'extend-ds-model',
-  before:     'store',
+  before:     'ember-data',
   initialize: initialize
 };

--- a/addon/initializers/syncer.js
+++ b/addon/initializers/syncer.js
@@ -8,7 +8,7 @@ export function initialize(container, application) {
 
 export default {
   name:       'syncer',
-  before:     'store',
+  before:     'ember-data',
   after:      'extend-ds-model',
   initialize: initialize
 };


### PR DESCRIPTION
…  initializer

Hello, The `store` initializer target currently is a [empty initializer](https://github.com/emberjs/data/blob/master/app/initializers/store.js#L10-L14) in Ember Data. I have an [RFC](https://github.com/emberjs/rfcs/pull/181) and a [PR](https://github.com/emberjs/data/pull/4657) to deprecate it a future Ember Data release. I did a search and found your addon is using the `store` initializer  target and I have opened this pr for you to use the `'ember-data'` initializer instead which will continue to be supported after the empty initializers are deprecated.